### PR TITLE
fixed issue with fluentd rbac template

### DIFF
--- a/efk-stack/templates/fluentd-rbac.yaml
+++ b/efk-stack/templates/fluentd-rbac.yaml
@@ -32,4 +32,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "efk-stack.fullname" . }}-fluentd
-  namespace: logging
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
The fluentd rbac template had the namespace for the clusterRoleBinding set as "logging" instead of being dynamically set by the release namespace.