### PR TITLE
fixed issue with fluentd SA namespace

### DIFF
--- a/efk-stack/templates/fluentd-rbac.yaml
+++ b/efk-stack/templates/fluentd-rbac.yaml
@@ -32,4 +32,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "efk-stack.fullname" . }}-fluentd
-  namespace: logging
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
it was set statically to "logging" instead of receiving it dynamically from the helm release's namespace.